### PR TITLE
Atualiza propriedades de transação e lógica de parser para Description

### DIFF
--- a/OFXParser/Core/Parser.cs
+++ b/OFXParser/Core/Parser.cs
@@ -212,7 +212,13 @@ namespace OFXParser
                             case "MEMO":
                                 if (currentTransaction != null)
                                 {
-                                    currentTransaction.Description = string.IsNullOrEmpty(xmlTextReader.Value) ? string.Empty : xmlTextReader.Value.Trim().Replace("  ", " ");
+                                    currentTransaction.Memo = string.IsNullOrEmpty(xmlTextReader.Value) ? string.Empty : xmlTextReader.Value.Trim().Replace("  ", " ");
+                                }
+                                break;
+                            case "NAME":
+                                if (currentTransaction != null)
+                                {
+                                    currentTransaction.Name = string.IsNullOrEmpty(xmlTextReader.Value) ? string.Empty : xmlTextReader.Value.Trim().Replace("  ", " ");
                                 }
                                 break;
                         }

--- a/OFXParser/Entities/Transaction.cs
+++ b/OFXParser/Entities/Transaction.cs
@@ -12,9 +12,12 @@ namespace OFXParser.Entities
 
         public string Id { get; set; }
 
-        public string Description { get; set; }
+        public string Description => !string.IsNullOrEmpty(Memo) ? Memo : Name;
 
         public long Checksum { get; set; }
 
+        public string Memo { get; set; }
+
+        public string Name { get; set; }
     }
 }


### PR DESCRIPTION
Substitui a propriedade `Description` na classe `Transaction` por uma propriedade calculada que utiliza `Memo` ou `Name`. Adiciona a nova propriedade `Memo` e ajusta a lógica no `Parser.cs` para preencher `Memo` em vez de `Description`, mantendo o tratamento de valores nulos e espaços em branco.

Isto acontece para os bancos que não utilizam o Memo, e sim o Name para o texto das transações. Como acontece com o banco Caixa Econômica Federal.

Para não quebrar nenhum programa existente, a propriedade "Description" pega primeiramente a propriedade Memo, como era o padrão. Caso esteja em branco, pega a propriedade Name.