### PR TITLE
Support for the new Checknum property in transactions

### DIFF
--- a/OFXParser/Core/Parser.cs
+++ b/OFXParser/Core/Parser.cs
@@ -206,7 +206,12 @@ namespace OFXParser
                             case "CHECKNUM":
                                 if (currentTransaction != null)
                                 {
-                                    currentTransaction.Checksum = Convert.ToInt64(xmlTextReader.Value);
+                                    if (long.TryParse(xmlTextReader.Value, out long checksum)){
+                                        currentTransaction.Checksum = checksum;
+                                    }
+                                    if (decimal.TryParse(xmlTextReader.Value, out decimal checknum)){
+                                        currentTransaction.Checknum = checknum;
+                                    }
                                 }
                                 break;
                             case "MEMO":

--- a/OFXParser/Entities/Transaction.cs
+++ b/OFXParser/Entities/Transaction.cs
@@ -14,7 +14,9 @@ namespace OFXParser.Entities
 
         public string Description { get; set; }
 
+        [Obsolete("Use Checksum property instead")]
         public long Checksum { get; set; }
+        public decimal Checknum { get; set; }
 
     }
 }


### PR DESCRIPTION
Durante os testes foi identificado um erro ao processar um valor recebido do Banco Santander.
O valor foi:

<CHECKNUM>14102025184012020000

Devido a esse formato, não foi possível realizar a conversão para long, já que o conteúdo excede o limite.

Para manter a compatibilidade com implementações existentes, mantive o campo original como long, evitando impacto para quem já utiliza o código.
No entanto, adicionei um novo campo do tipo decimal, que permite receber corretamente valores maiores ou com casas decimais, garantindo o tratamento adequado desses casos.